### PR TITLE
Script execution fixes + Scripts screen run

### DIFF
--- a/app/src/main/java/micro/repl/ma7moud3ly/NavGraph.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/NavGraph.kt
@@ -134,6 +134,10 @@ fun RootGraph(
                     viewModel.openScript(microScript)
                     navController.navigate(AppRoutes.Editor())
                 },
+                onRunLocalScript = { microScript ->
+                    viewModel.openScript(microScript)
+                    navController.navigate(AppRoutes.Terminal)
+                },
                 onNewScript = {
                     viewModel.openScript(MicroScript())
                     navController.navigate(AppRoutes.Editor(blank = true))

--- a/app/src/main/java/micro/repl/ma7moud3ly/managers/TerminalManager.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/managers/TerminalManager.kt
@@ -11,6 +11,7 @@ import android.util.Log
 import kotlinx.coroutines.delay
 import micro.repl.ma7moud3ly.model.MicroDevice
 import micro.repl.ma7moud3ly.model.MicroScript
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Manages terminal commands for interacting with a MicroPython board.
@@ -111,18 +112,21 @@ class TerminalManager(
      * mode. The output of the script is not returned directly but may be printed
      * on the board's console.
      *
-     * @param code The MicroPython script to execute.
+     * @param microScript The MicroPython script to execute.
      */
     suspend fun executeLocalScript(
         microScript: MicroScript,
         onClear: () -> Unit
     ) {
-        // reset the device to clear previously imported modules
-        boardManager.writeCommand(CommandsManager.RESET)
-        delay(100)
-        onClear()
+        // stop any running code/loops
+        boardManager.writeCommand(CommandsManager.TERMINATE)
         // Start silent mode.
         boardManager.writeCommand(CommandsManager.SILENT_MODE)
+        // reset the device to clear previously imported modules
+        boardManager.writeCommand(CommandsManager.RESET)
+        // clear noise from the terminal outputs
+        delay(100.milliseconds)
+        onClear()
         // Print a new line to separate the silent mode message from the output.
         // And write the code to interpreter to execute it
         boardManager.writeCommand("print()\r\n${microScript.content}")
@@ -132,11 +136,14 @@ class TerminalManager(
         boardManager.writeCommand(CommandsManager.REPL_MODE)
     }
 
-    fun executeScript(microScript: MicroScript) {
+    suspend fun executeScript(microScript: MicroScript, onClear: () -> Unit) {
+        // Start silent mode.
+        boardManager.writeCommand(CommandsManager.SILENT_MODE)
         // reset the device to clear previously imported modules
         boardManager.writeCommand(CommandsManager.RESET)
-        // Start silent mode.
-        //boardManager.writeCommand(CommandsManager.SILENT_MODE)
+        // clear noise from the terminal outputs
+        delay(100.milliseconds)
+        onClear()
         // Locate the working directory to the script
         boardManager.write(CommandsManager.chDir(microScript.scriptDir))
         // Run the script

--- a/app/src/main/java/micro/repl/ma7moud3ly/screens/explorer/ExplorerScreen.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/screens/explorer/ExplorerScreen.kt
@@ -1,8 +1,10 @@
 package micro.repl.ma7moud3ly.screens.explorer
 
+import android.app.Activity
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -11,7 +13,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -55,7 +56,7 @@ fun FilesExplorerScreen(
     openEditor: (MicroScript) -> Unit,
     onBack: () -> Unit
 ) {
-    val context = LocalContext.current
+    val activity = LocalActivity.current as Activity
     val root by remember { viewModel.root }
     val coroutineScope = rememberCoroutineScope()
     val files = viewModel.files.collectAsState()
@@ -144,7 +145,7 @@ fun FilesExplorerScreen(
                 coroutineScope.launch {
                     filesManager.listDir()
                     withContext(Dispatchers.Main) {
-                        Toast.makeText(context, "saved to $root", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(activity, "saved to $root", Toast.LENGTH_SHORT).show()
                     }
                 }
             }
@@ -167,8 +168,8 @@ fun FilesExplorerScreen(
      */
     fun onRefresh() {
         Log.i(TAG, "onRefresh")
-        val msg = context.getText(R.string.explorer_refresh)
-        Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+        val msg = activity.getText(R.string.explorer_refresh)
+        Toast.makeText(activity, msg, Toast.LENGTH_SHORT).show()
         filesManager?.listDir()
     }
 

--- a/app/src/main/java/micro/repl/ma7moud3ly/screens/scripts/ScriptsContent.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/screens/scripts/ScriptsContent.kt
@@ -174,6 +174,13 @@ private fun ItemScript(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
+            ActionButton(
+                text = R.string.terminal_run,
+                filled = true,
+                textModifier = Modifier.padding(horizontal = 14.dp),
+                onClick = onRun
+            )
+
             ScriptIcon(
                 icon = R.drawable.share,
                 modifier = Modifier.size(18.dp),
@@ -191,15 +198,6 @@ private fun ItemScript(
                 description = R.string.explorer_delete,
                 onClick = onDelete
             )
-
-            /*if (script.isPython) Icon(
-                painter = painterResource(id = R.drawable.run),
-                contentDescription = stringResource(id = R.string.explorer_run),
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier
-                    .size(editorIconSize)
-                    .clickable { onRun.invoke(script) }
-            )*/
         }
     }
 }

--- a/app/src/main/java/micro/repl/ma7moud3ly/screens/scripts/ScriptsScreen.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/screens/scripts/ScriptsScreen.kt
@@ -26,7 +26,8 @@ private const val TAG = "ScriptsScreen"
 fun ScriptsScreen(
     onBack: () -> Unit,
     onNewScript: () -> Unit,
-    onOpenLocalScript: (MicroScript) -> Unit
+    onOpenLocalScript: (MicroScript) -> Unit,
+    onRunLocalScript: (MicroScript) -> Unit
 ) {
     val context = LocalContext.current
     val scriptsManager = remember { ScriptsManager(context) }
@@ -62,6 +63,17 @@ fun ScriptsScreen(
         }
     }
 
+    fun runLocalScript(script: MicroScript) {
+        try {
+            val content = scriptsManager.read(script.file)
+            script.content = content
+            Log.v(TAG, script.toString())
+            onRunLocalScript(script)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
     ScriptsScreenContent(
         scripts = { scripts },
         uiEvents = {
@@ -69,6 +81,7 @@ fun ScriptsScreen(
                 is ScriptsEvents.Back -> onBack()
                 is ScriptsEvents.NewScript -> onNewScript()
                 is ScriptsEvents.Open -> readLocalScript(it.script)
+                is ScriptsEvents.Run -> runLocalScript(it.script)
                 is ScriptsEvents.Share -> scriptsManager.shareScript(it.script)
                 is ScriptsEvents.Delete -> {
                     selectedScript = it.script
@@ -79,8 +92,6 @@ fun ScriptsScreen(
                     selectedScript = it.script
                     renameFileDialog.show()
                 }
-
-                is ScriptsEvents.Run -> {}
             }
         }
     )

--- a/app/src/main/java/micro/repl/ma7moud3ly/screens/terminal/TerminalScreen.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/screens/terminal/TerminalScreen.kt
@@ -1,7 +1,9 @@
 package micro.repl.ma7moud3ly.screens.terminal
 
+import android.app.Activity
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -9,7 +11,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -34,7 +35,7 @@ fun TerminalScreen(
     terminalManager: TerminalManager,
     onBack: () -> Unit
 ) {
-    val context = LocalContext.current
+    val activity = LocalActivity.current as Activity
     val coroutineScope = rememberCoroutineScope()
     var terminalInput by remember { viewModel.terminalInput }
     var terminalOutput by remember { viewModel.terminalOutput }
@@ -52,19 +53,24 @@ fun TerminalScreen(
         }
     }
 
+    fun clear() {
+        terminalInput = ""
+        terminalOutput = ""
+    }
+
     fun executeScript() {
         coroutineScope.launch {
             withContext(Dispatchers.IO) {
                 if (microScript.isLocal) {
                     terminalManager.executeLocalScript(
                         microScript = microScript,
-                        onClear = {
-                            terminalInput = ""
-                            terminalOutput = ""
-                        }
+                        onClear = ::clear
                     )
                 } else {
-                    terminalManager.executeScript(microScript)
+                    terminalManager.executeScript(
+                        microScript = microScript,
+                        onClear = ::clear
+                    )
                 }
             }
         }
@@ -73,8 +79,8 @@ fun TerminalScreen(
     fun onTerminate(showMessage: Boolean = false) {
         terminalManager.terminateExecution()
         if (showMessage) Toast.makeText(
-            context,
-            context.getString(R.string.terminal_terminate_msg),
+            activity,
+            activity.getString(R.string.terminal_terminate_msg),
             Toast.LENGTH_SHORT
         ).show()
     }
@@ -82,8 +88,8 @@ fun TerminalScreen(
     fun onSoftReset() {
         terminalManager.softResetDevice {
             Toast.makeText(
-                context,
-                context.getString(R.string.terminal_soft_reset_msg),
+                activity,
+                activity.getString(R.string.terminal_soft_reset_msg),
                 Toast.LENGTH_SHORT
             ).show()
         }
@@ -100,8 +106,7 @@ fun TerminalScreen(
 
     DisposableEffect(LocalLifecycleOwner.current) {
         onDispose {
-            terminalOutput = ""
-            terminalInput = ""
+            clear()
             onTerminate()
         }
     }
@@ -113,8 +118,7 @@ fun TerminalScreen(
             TerminalEvents.Terminate -> onTerminate(true)
 
             TerminalEvents.Clear -> {
-                terminalInput = ""
-                terminalOutput = ""
+                clear()
             }
 
             TerminalEvents.MoveDown -> {

--- a/app/src/main/java/micro/repl/ma7moud3ly/ui/components/Widgets.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/ui/components/Widgets.kt
@@ -7,10 +7,9 @@
 
 package micro.repl.ma7moud3ly.ui.components
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -26,10 +25,11 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun ProgressView() {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(top = 20.dp),
+        contentAlignment = Alignment.Center
     ) {
         CircularProgressIndicator(
             color = Color.Green.copy(alpha = 0.2f)


### PR DESCRIPTION
## Script execution fixes + Scripts screen run

### Fix: running a script while the board is busy
Running a script left terminal noise behind and misbehaved when a loop was
already running on the board (for example `main.py` after a soft reboot).
Both local and remote paths now enter silent mode first, then clear the
terminal, so the reboot banner and leftover output don't leak into the view.

### Run scripts from the Scripts screen
Local scripts can now be run directly from the Scripts list, instead of having
to open them in the editor first.
