### PR TITLE
fix: update nemoEditor to 1.0.4 to resolve undo crash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "micro.repl.ma7moud3ly"
         minSdk = 23
         targetSdk = 37
-        versionCode = 16
-        versionName = "3.0"
+        versionCode = 17
+        versionName = "3.1"
         multiDexEnabled = true
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ composeUi = "1.12.0"
 firebaseBom = "34.18.0"
 googleServices = "4.5.0"
 
-nemoEditor = "1.0.3"
+nemoEditor = "1.0.4"
 usbSerialForAndroid = "3.9.0"
 serialization = "1.11.0"
 


### PR DESCRIPTION
- Update nemoEditor from 1.0.3 to 1.0.4 to fix undo/redo crash
- Bump app version to 3.1 (versionCode 17)