### PR TITLE
fix(editor): retain state across rotation

### DIFF
--- a/app/src/main/java/micro/repl/ma7moud3ly/NavGraph.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/NavGraph.kt
@@ -116,11 +116,12 @@ fun RootGraph(
                     navController.navigate(AppRoutes.Terminal)
                 },
                 onBack = {
-                    // The editor can be reached from the explorer, which is
-                    // useless once the board is gone. Going back there would
-                    // land on a dead file list, so skip to Home instead.
-                    if (canRun) navController.popBackStack()
-                    else navController.popBackStack(AppRoutes.Home, inclusive = false)
+                    // Only the explorer is dead without a board, so that's the
+                    // one worth skipping past. Scripts works offline - go back to it as normal.
+                    val previous = navController.previousBackStackEntry?.destination
+                    val skip = canRun.not() && previous?.hasRoute(AppRoutes.Explorer::class) == true
+                    if (skip) navController.popBackStack(AppRoutes.Home, inclusive = false)
+                    else navController.popBackStack()
                 }
             )
         }

--- a/app/src/main/java/micro/repl/ma7moud3ly/NavGraph.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/NavGraph.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -15,9 +16,9 @@ import androidx.navigation.toRoute
 import micro.repl.ma7moud3ly.managers.BoardManager
 import micro.repl.ma7moud3ly.managers.FilesManager
 import micro.repl.ma7moud3ly.managers.TerminalManager
+import micro.repl.ma7moud3ly.model.AppRoutes
 import micro.repl.ma7moud3ly.model.ConnectionStatus
 import micro.repl.ma7moud3ly.model.MicroScript
-import micro.repl.ma7moud3ly.model.AppRoutes
 import micro.repl.ma7moud3ly.screens.dialogs.ThemeSelectorDialog
 import micro.repl.ma7moud3ly.screens.editor.EditorScreen
 import micro.repl.ma7moud3ly.screens.explorer.FilesExplorerScreen
@@ -40,7 +41,13 @@ fun RootGraph(
                 is ConnectionStatus.Connected -> canRun = true
                 else -> {
                     canRun = false
-                    navController.popBackStack(AppRoutes.Home, inclusive = false)
+                    // If the board is disconnected, go back to Home.
+                    // Don't go back to Home when the Editor is open,
+                    // so the current script remains open.
+                    val destination = navController.currentDestination
+                    if (destination?.hasRoute(AppRoutes.Editor::class) == false) {
+                        navController.popBackStack(AppRoutes.Home, inclusive = false)
+                    }
                 }
             }
         }
@@ -108,7 +115,13 @@ fun RootGraph(
                     viewModel.openScript(s)
                     navController.navigate(AppRoutes.Terminal)
                 },
-                onBack = { navController.popBackStack() }
+                onBack = {
+                    // The editor can be reached from the explorer, which is
+                    // useless once the board is gone. Going back there would
+                    // land on a dead file list, so skip to Home instead.
+                    if (canRun) navController.popBackStack()
+                    else navController.popBackStack(AppRoutes.Home, inclusive = false)
+                }
             )
         }
 

--- a/app/src/main/java/micro/repl/ma7moud3ly/managers/EditorManager.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/managers/EditorManager.kt
@@ -12,79 +12,81 @@ import android.content.Context
 import android.util.Log
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.State
 import androidx.core.content.edit
 import io.ma7moud3ly.nemo.model.CodeState
 import io.ma7moud3ly.nemo.model.EditorSettings
 import io.ma7moud3ly.nemo.model.EditorTheme
-import io.ma7moud3ly.nemo.model.Language
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import micro.repl.ma7moud3ly.R
 import micro.repl.ma7moud3ly.model.MicroScript
 import java.io.File
-import java.io.IOException
+
 
 /**
- * Single state facade for the editor screen.
+ * Manages the state and actions of the code editor.
  *
- * The manager owns the Nemo [CodeState] (text + undo/redo history) and
- * [EditorSettings] (theme, line numbers, font size) and exposes the small bit of
- * script identity the UI needs (title, path, script flags, run availability).
- * The UI reads everything from this one object — there is no separate mirror
- * state and no reactive syncing.
+ * This class handles editor settings, code execution, file operations (save, undo/redo),
+ * and coordinates between the UI and the underlying [EditorSession].
  *
- * Use [EditorManager.create] to build an instance for the real screen (it reads
- * persisted preferences and restores the recent script). The primary constructor
- * is intentionally free of `Activity`/filesystem work so it stays usable in
- * `@Preview`.
+ * @param context The Android context.
+ * @param coroutineScope The scope for running asynchronous operations like file I/O.
+ * @param session The current editor session containing code and script metadata.
+ * @param filesManager Optional manager for remote file operations on a MicroPython board.
+ * @param runnable A function that returns true if the script can currently be executed.
+ * @param settings The configuration for the editor (theme, font size, etc.).
+ * @param onRun Callback invoked when the user requests to run the script.
+ * @param afterEdit Callback invoked after a script is closed or edit is finished.
  */
 class EditorManager(
     private val context: Context,
     private val coroutineScope: CoroutineScope,
-    val codeState: CodeState,
-    val settings: EditorSettings,
-    initialScript: MicroScript,
+    private val session: EditorSession,
     private val filesManager: FilesManager? = null,
+    private val runnable: () -> Boolean = { false },
+    val settings: EditorSettings,
     private val onRun: ((MicroScript) -> Unit)? = null,
     private val afterEdit: (() -> Unit)? = null
 ) {
     // Built lazily so the constructor stays preview-safe.
     private val scriptsManager by lazy { ScriptsManager(context) }
 
-    private var script: MicroScript = initialScript
+    val codeState: CodeState get() = session.codeState
+    val script: MicroScript get() = session.script
+    val isLocal: Boolean get() = script.isLocal
+    val isMicroPython: Boolean get() = script.microPython
+    val isPython: Boolean get() = script.isPython
+    val scriptName: String get() = script.name
 
-    // The last persisted content; the diff against it is our "dirty" signal.
-    private var savedContent: String = initialScript.content
+    /** The editor title (file name / path), shown in the header. */
+    val title: State<String> = derivedStateOf { script.displayName }
 
     var actionAfterSave: EditorAction? = null
 
-    /** The editor title (file name / path), shown in the header. */
-    val title = mutableStateOf(initialScript.path)
-
-    /** Whether the run button is available. */
-    val canRun = mutableStateOf(false)
-
     /**
-     * Script identity, derived from the current [script].
+     * Whether the run button is available.
+     *
+     * Derived rather than mirrored: reading it in composition tracks the
+     * connection state directly, so it goes false again on disconnect.
      */
-    val isLocal: Boolean get() = script.isLocal
-    val microPython: Boolean get() = script.microPython
-    val isPython: Boolean get() = script.isPython
-    val path: String get() = script.path
-    val exists: Boolean get() = script.exists || script.path.isNotEmpty()
+    val canRun: Boolean get() = runnable()
+
+    /** Whether there are edits that haven't been written back yet. */
+    val isDirty: Boolean get() = session.isDirty
 
     /**
-     * Undo/redo availability, derived from [codeState]. Reading [codeState.code]
-     * (a snapshot state) inside the derivation makes these recompose on every
-     * edit/undo/redo.
+     * Whether the undo is available.
      */
     val canUndo: Boolean by derivedStateOf {
         codeState.code
         codeState.canUndo()
     }
+
+    /**
+     * Whether the redo is available.
+     */
     val canRedo: Boolean by derivedStateOf {
         codeState.code
         codeState.canRedo()
@@ -93,12 +95,7 @@ class EditorManager(
     /** Line-numbers visibility, owned by [settings]. */
     val showLines: Boolean get() = settings.showLineNumbersState.value
 
-    private val asMicroScript: MicroScript
-        get() = MicroScript(
-            content = codeState.code,
-            path = script.path,
-            editorMode = script.editorMode
-        )
+    private val asMicroScript: MicroScript get() = session.asMicroScript
 
     /**
      * Editor actions
@@ -142,13 +139,7 @@ class EditorManager(
         val action = this.actionAfterSave
         actionAfterSave = null
         when (action) {
-            EditorAction.NewScript -> {
-                codeState.updateText("")
-                codeState.clearHistory()
-                script = MicroScript(editorMode = script.editorMode)
-                savedContent = ""
-                title.value = context.getString(R.string.editor_untitled)
-            }
+            EditorAction.NewScript -> session.reset()
 
             EditorAction.CLoseScript -> afterEdit?.invoke()
             EditorAction.RunScript -> onRun?.invoke(asMicroScript)
@@ -157,37 +148,32 @@ class EditorManager(
     }
 
     /** True if the script exists and has unsaved changes. */
-    fun saveExisting(): Boolean {
-        val exist = exists && codeState.code != savedContent
-        Log.v(TAG, "saveExisting  - $exist")
-        return exist
-    }
+    fun saveExisting(): Boolean = session.isDirty
 
     /** True if the script is new (no path) and has content. */
-    fun saveNew(): Boolean {
-        val new = exists.not() && codeState.code.isNotEmpty()
-        Log.v(TAG, "saveNew - $new")
-        return new
-    }
+    fun saveNew(): Boolean = session.isNew
 
     /**
      * Saves the current script locally or to the MicroPython board.
+     *
+     * The local write is real file I/O, so it runs off the main thread; [onDone]
+     * is always invoked on Main, matching the remote path.
      */
     fun save(onDone: () -> Unit) {
-        if (isLocal) {
+        if (script.isLocal) {
             val file = File(script.path)
-            val saved = scriptsManager.write(file, codeState.code)
-            if (saved) {
-                savedContent = codeState.code
-                title.value = file.name
+            val content = codeState.code
+            coroutineScope.launch {
+                val saved = withContext(Dispatchers.IO) { scriptsManager.write(file, content) }
+                if (saved) session.markSaved()
+                onDone()
             }
-            onDone()
         } else {
             filesManager?.write(
                 path = script.path,
                 content = codeState.code,
                 onSave = {
-                    savedContent = codeState.code
+                    session.markSaved()
                     coroutineScope.launch {
                         withContext(Dispatchers.Main) {
                             onDone()
@@ -203,8 +189,7 @@ class EditorManager(
      */
     fun saveFileAs(name: String, onDone: () -> Unit) {
         scriptsManager.scriptDirectory()?.let {
-            script = script.copy(path = it.path + "/" + name)
-            title.value = name
+            session.moveTo(it.path + "/" + name)
             Log.v(TAG, "saveFileAs - ${script.path}")
             save(onDone)
         }
@@ -215,7 +200,7 @@ class EditorManager(
         activity.getPreferences(Context.MODE_PRIVATE).edit {
             putBoolean(KEY_SHOW_LINES, settings.showLineNumbersState.value)
             putInt(KEY_FONT_SIZE, settings.fontSizeState.value)
-            if (isLocal && exists) {
+            if (script.isLocal && script.exists) {
                 Log.v(TAG, "persistSettings - hasScript")
                 putString(KEY_SCRIPT, script.path)
             }
@@ -226,70 +211,43 @@ class EditorManager(
         private const val TAG = "EditorManager"
         private const val KEY_SHOW_LINES = "show_lines"
         private const val KEY_FONT_SIZE = "font_size"
-        private const val KEY_SCRIPT = "script"
+        internal const val KEY_SCRIPT = "script"
 
         /**
-         * Builds an [EditorManager] for the real screen: reads persisted settings,
-         * restores the recent local script when opening without one, and creates
-         * the Nemo [CodeState]/[EditorSettings].
+         * Builds an [EditorManager] around an existing [session].
+         *
+         * The session is passed in rather than created here so the caller can
+         * `retain` it across a rotation; everything built here (scope, callbacks,
+         * the FilesManager) is tied to the current Activity and must not be.
          */
         fun create(
             context: Context,
             coroutineScope: CoroutineScope,
-            script: MicroScript,
-            blank: Boolean,
+            session: EditorSession,
             theme: EditorTheme,
+            runnable: () -> Boolean = { false },
             filesManager: FilesManager? = null,
             onRun: ((MicroScript) -> Unit)? = null,
             afterEdit: (() -> Unit)? = null
         ): EditorManager {
             val activity = context as Activity
             val sharedPref = activity.getPreferences(Context.MODE_PRIVATE)
-            val resolved = restoreRecentScript(context, sharedPref, script, blank)
-
             val settings = EditorSettings(
                 theme = theme,
                 // EditorSettings requires fontSize in 8..32.
                 fontSize = sharedPref.getInt(KEY_FONT_SIZE, 14).coerceIn(8, 32),
                 showLineNumbers = sharedPref.getBoolean(KEY_SHOW_LINES, true)
             )
-            val codeState = CodeState(
-                initialCode = resolved.content,
-                language = Language.MICRO_PYTHON,
-            )
             return EditorManager(
                 context = context,
                 coroutineScope = coroutineScope,
-                codeState = codeState,
+                session = session,
                 settings = settings,
-                initialScript = resolved,
                 filesManager = filesManager,
+                runnable = runnable,
                 onRun = onRun,
                 afterEdit = afterEdit
             )
-        }
-
-        /**
-         * Returns the recent local script when the editor is opened without a
-         * script; otherwise returns [script] unchanged.
-         */
-        private fun restoreRecentScript(
-            context: Context,
-            sharedPref: android.content.SharedPreferences,
-            script: MicroScript,
-            blank: Boolean
-        ): MicroScript {
-            if (blank || script.isLocal.not() || script.exists) return script
-            val recent = sharedPref.getString(KEY_SCRIPT, "").orEmpty()
-            if (recent.isEmpty()) return script
-            val file = File(recent)
-            if (file.exists().not()) return script
-            return try {
-                script.copy(content = ScriptsManager(context).read(file), path = recent)
-            } catch (e: IOException) {
-                e.printStackTrace()
-                script
-            }
         }
     }
 }

--- a/app/src/main/java/micro/repl/ma7moud3ly/managers/EditorSession.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/managers/EditorSession.kt
@@ -1,0 +1,126 @@
+/*
+ * Created by Mahmoud Aly - engma7moud3ly@gmail.com
+ * Project Micro REPL - https://github.com/Ma7moud3ly/micro-repl
+ * Copyright (c) 2023 . MIT license.
+ *
+ */
+
+package micro.repl.ma7moud3ly.managers
+
+import android.app.Activity
+import android.content.Context
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import io.ma7moud3ly.nemo.model.CodeState
+import io.ma7moud3ly.nemo.model.Language
+import micro.repl.ma7moud3ly.model.MicroScript
+import java.io.File
+import java.io.IOException
+
+/**
+ * What the editor is working on: the buffer, the file it belongs to, and the
+ * baseline used to tell whether there are unsaved changes.
+ *
+ */
+class EditorSession(
+    val codeState: CodeState,
+    initialScript: MicroScript
+) {
+    /** The file being edited. Changes on "save as" and "new". */
+    var script by mutableStateOf(initialScript)
+        private set
+
+    /** Content as of the last successful save; the baseline for [isDirty]. */
+    var savedContent by mutableStateOf(initialScript.content)
+        private set
+
+    /**
+     * A saved script with edits that haven't been written back yet.
+     *
+     * Derived rather than a plain getter so readers wake only when the flag
+     * itself flips. A getter would subscribe them to `codeState.code` and
+     * recompose on every keystroke, even though this stays true throughout.
+     */
+    val isDirty: Boolean by derivedStateOf {
+        script.exists && codeState.code != savedContent
+    }
+
+    /** A script with content but no path yet, so it needs a name before saving. */
+    val isNew: Boolean get() = script.exists.not() && codeState.code.isNotEmpty()
+
+    /** The buffer as a script: the live text, with the path and mode it belongs to. */
+    val asMicroScript: MicroScript
+        get() = MicroScript(
+            content = codeState.code,
+            path = script.path,
+            editorMode = script.editorMode
+        )
+
+    /** Records a successful save, which clears [isDirty]. */
+    fun markSaved() {
+        savedContent = codeState.code
+    }
+
+    /** Points the session at a new path, for "save as". */
+    fun moveTo(path: String) {
+        script = script.copy(path = path)
+    }
+
+    /** Empties the editor for a new, unnamed script, keeping the current mode. */
+    fun reset() {
+        codeState.updateText("")
+        codeState.clearHistory()
+        script = MicroScript(editorMode = script.editorMode)
+        savedContent = ""
+    }
+
+    companion object {
+
+        /**
+         * Builds a session for [script], restoring the most recent local script
+         * when the editor is opened without one.
+         *
+         * [context] is only read here; nothing keeps a reference to it.
+         */
+        fun create(
+            context: Context,
+            script: MicroScript,
+            blank: Boolean
+        ): EditorSession {
+            val resolved = restoreRecentScript(context, script, blank)
+            return EditorSession(
+                codeState = CodeState(
+                    initialCode = resolved.content,
+                    language = Language.MICRO_PYTHON
+                ),
+                initialScript = resolved
+            )
+        }
+
+        /**
+         * Returns the recent local script when the editor is opened without a
+         * script; otherwise returns [script] unchanged.
+         */
+        private fun restoreRecentScript(
+            context: Context,
+            script: MicroScript,
+            blank: Boolean
+        ): MicroScript {
+            if (blank || script.isLocal.not() || script.exists) return script
+            val activity = context as? Activity ?: return script
+            val recent = activity.getPreferences(Context.MODE_PRIVATE)
+                .getString(EditorManager.KEY_SCRIPT, "").orEmpty()
+            if (recent.isEmpty()) return script
+            val file = File(recent)
+            if (file.exists().not()) return script
+            return try {
+                script.copy(content = ScriptsManager(context).read(file), path = recent)
+            } catch (e: IOException) {
+                e.printStackTrace()
+                script
+            }
+        }
+    }
+}

--- a/app/src/main/java/micro/repl/ma7moud3ly/model/MicroScript.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/model/MicroScript.kt
@@ -14,6 +14,12 @@ data class MicroScript(
     val scriptDir: String get() = file.parent.orEmpty()
     val nameWithoutExt: String get() = name.replace(".py", "")
     val name: String get() = path.substringAfterLast('/')
+    val displayName: String
+        get() = when {
+            exists.not() -> "/untitled"
+            isLocal -> "/$name"
+            else -> path
+        }
     val isPython: Boolean get() = name.trim().endsWith(".py")
     val isLocal: Boolean get() = editorMode == EditorMode.LOCAL
 }

--- a/app/src/main/java/micro/repl/ma7moud3ly/screens/editor/EditorContent.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/screens/editor/EditorContent.kt
@@ -1,5 +1,11 @@
 package micro.repl.ma7moud3ly.screens.editor
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -37,6 +43,7 @@ import io.ma7moud3ly.nemo.model.EditorThemes
 import io.ma7moud3ly.nemo.model.Language
 import micro.repl.ma7moud3ly.R
 import micro.repl.ma7moud3ly.managers.EditorManager
+import micro.repl.ma7moud3ly.managers.EditorSession
 import micro.repl.ma7moud3ly.model.EditorMode
 import micro.repl.ma7moud3ly.model.MicroScript
 import micro.repl.ma7moud3ly.ui.components.ActionButton
@@ -59,14 +66,17 @@ private fun EditorScreenPreviewLight() {
         EditorManager(
             context = context,
             coroutineScope = scope,
-            codeState = CodeState("print('Hello World')", Language.PYTHON),
+            session = EditorSession(
+                codeState = CodeState("print('Hello World')", Language.PYTHON),
+                initialScript = MicroScript(
+                    path = "lib/path/path/path/path/path/main.py",
+                    editorMode = EditorMode.REMOTE,
+                    microPython = true
+                )
+            ),
             settings = EditorSettings(theme = EditorThemes.VS_CODE_LIGHT),
-            initialScript = MicroScript(
-                path = "lib/path/path/path/path/path/main.py",
-                editorMode = EditorMode.REMOTE,
-                microPython = true
-            )
-        ).apply { canRun.value = true }
+            runnable = { true }
+        )
     }
     AppTheme(darkTheme = false) {
         EditorScreenContent(
@@ -85,14 +95,17 @@ private fun EditorScreenPreviewDark() {
         EditorManager(
             context = context,
             coroutineScope = scope,
-            codeState = CodeState("print('Hello World')", Language.PYTHON),
+            session = EditorSession(
+                codeState = CodeState("print('Hello World')", Language.PYTHON),
+                initialScript = MicroScript(
+                    path = "lib/path/path/path/path/path/main.py",
+                    editorMode = EditorMode.REMOTE,
+                    microPython = true
+                )
+            ),
             settings = EditorSettings(),
-            initialScript = MicroScript(
-                path = "lib/path/path/path/path/path/main.py",
-                editorMode = EditorMode.REMOTE,
-                microPython = true
-            )
-        ).apply { canRun.value = true }
+            runnable = { true }
+        )
     }
     AppTheme(darkTheme = true) {
         EditorScreenContent(
@@ -146,6 +159,13 @@ private fun EditorAppBar(
     uiEvents: (EditorEvents) -> Unit
 ) {
     val title by editorManager.title
+    val source = stringResource(
+        when {
+            editorManager.isLocal -> R.string.this_device
+            editorManager.isMicroPython -> R.string.micro_python
+            else -> R.string.circuit_python
+        }
+    )
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -154,16 +174,9 @@ private fun EditorAppBar(
         verticalAlignment = Alignment.CenterVertically
     ) {
         BackButton { uiEvents(EditorEvents.Back) }
-        val source = stringResource(
-            when {
-                editorManager.isLocal -> R.string.this_device
-                editorManager.microPython -> R.string.micro_python
-                else -> R.string.circuit_python
-            }
-        )
         ScriptTitle(
             source = source,
-            name = title.ifEmpty { "/" + stringResource(R.string.editor_untitled) },
+            name = title,
             modifier = Modifier.weight(1f)
         )
         ThemeButton(onClick = { uiEvents(EditorEvents.ShowThemeDialog) })
@@ -177,7 +190,8 @@ private fun EditorActions(
     editorManager: EditorManager,
     uiEvents: (EditorEvents) -> Unit
 ) {
-    val canRun by editorManager.canRun
+    val canRun = editorManager.canRun
+    val isDirty = editorManager.isDirty
     val canUndo = editorManager.canUndo
     val canRedo = editorManager.canRedo
     val showLines = editorManager.showLines
@@ -204,11 +218,21 @@ private fun EditorActions(
                     textModifier = Modifier.padding(horizontal = 14.dp),
                     onClick = { uiEvents(EditorEvents.Run) }
                 )
-                ActionButton(
-                    text = R.string.editor_save,
-                    textModifier = Modifier.padding(horizontal = 14.dp),
-                    onClick = { uiEvents(EditorEvents.Save) }
-                )
+                Box {
+                    ActionButton(
+                        text = R.string.editor_save,
+                        textModifier = Modifier.padding(horizontal = 14.dp),
+                        onClick = { uiEvents(EditorEvents.Save) }
+                    )
+                    if (isDirty) Box(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .offset(x = (-5).dp, y = (5).dp)
+                            .size(5.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.error)
+                    )
+                }
                 if (editorManager.isLocal) ActionButton(
                     text = R.string.editor_new,
                     textModifier = Modifier.padding(horizontal = 14.dp),
@@ -246,8 +270,8 @@ private fun EditorActions(
                 )
             }
         }
-        }
     }
+}
 
 @Composable
 private fun ScriptTitle(
@@ -273,7 +297,7 @@ private fun ScriptTitle(
                 text = name,
                 fontFamily = fontConsolas,
                 fontSize = 12.sp,
-                fontWeight = FontWeight.Normal,
+                fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
                 overflow = TextOverflow.MiddleEllipsis,

--- a/app/src/main/java/micro/repl/ma7moud3ly/screens/editor/EditorContent.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/screens/editor/EditorContent.kt
@@ -218,7 +218,9 @@ private fun EditorActions(
                     textModifier = Modifier.padding(horizontal = 14.dp),
                     onClick = { uiEvents(EditorEvents.Run) }
                 )
-                Box {
+                // A remote script has nowhere to save without the board connected,
+                // so the write would fail silently.
+                if (canRun || editorManager.isLocal) Box {
                     ActionButton(
                         text = R.string.editor_save,
                         textModifier = Modifier.padding(horizontal = 14.dp),

--- a/app/src/main/java/micro/repl/ma7moud3ly/screens/editor/EditorScreen.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/screens/editor/EditorScreen.kt
@@ -8,9 +8,11 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.retain.retain
 import androidx.compose.ui.platform.LocalContext
 import micro.repl.ma7moud3ly.managers.EditorAction
 import micro.repl.ma7moud3ly.managers.EditorManager
+import micro.repl.ma7moud3ly.managers.EditorSession
 import micro.repl.ma7moud3ly.managers.FilesManager
 import micro.repl.ma7moud3ly.model.MicroScript
 import micro.repl.ma7moud3ly.screens.dialogs.FileSaveAsDialog
@@ -36,13 +38,16 @@ fun EditorScreen(
     val saveAsNewDialog = rememberMyDialogState()
     val themeController = LocalThemeController.current
 
-    val editorManager = remember {
+
+    val editorSession = retain<EditorSession> { EditorSession.create(context, script, blank) }
+
+    val editorManager = remember(editorSession) {
         EditorManager.create(
             context = context,
             coroutineScope = coroutineScope,
-            script = script,
-            blank = blank,
+            session = editorSession,
             theme = themeController.theme,
+            runnable = canRun,
             filesManager = filesManager,
             onRun = onRemoteRun,
             afterEdit = onBack
@@ -54,19 +59,22 @@ fun EditorScreen(
         editorManager.settings.themeState.value = themeController.theme
     }
 
-    LaunchedEffect(canRun()) {
-        if (canRun()) editorManager.canRun.value = true
-    }
 
     fun checkAction(action: EditorAction) {
         Log.i(TAG, "action - $action")
         editorManager.actionAfterSave = action
-        if (editorManager.saveExisting()) {
-            if (action == EditorAction.SaveScript) editorManager.save {
+        if (editorManager.saveExisting()) when (action) {
+            EditorAction.SaveScript -> editorManager.save {
                 Toast.makeText(context, "Saved...", Toast.LENGTH_SHORT).show()
-            } else {
-                saveDialog.show()
             }
+
+            // Running always uses the latest text, so save first instead of asking.
+            EditorAction.RunScript -> editorManager.save {
+                editorManager.actionAfterSave()
+            }
+
+            // Closing or starting a new script can discard work, so ask.
+            else -> saveDialog.show()
         } else if (editorManager.saveNew()) {
             saveAsNewDialog.show()
         } else {
@@ -86,7 +94,7 @@ fun EditorScreen(
 
     FileSaveDialog(
         state = saveDialog,
-        name = { editorManager.title.value },
+        name = { editorManager.scriptName },
         onOk = {
             editorManager.save {
                 editorManager.actionAfterSave()

--- a/app/src/main/java/micro/repl/ma7moud3ly/screens/terminal/TerminalContent.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/screens/terminal/TerminalContent.kt
@@ -119,7 +119,10 @@ fun TerminalScreenContent(
     ) {
         TerminalOutput(
             output = terminalOutput,
-            fontSize = { fontSize }
+            fontSize = { fontSize },
+            // fill = false so short output sits right above the prompt;
+            // long output is capped here instead of pushing it off-screen.
+            modifier = Modifier.weight(1f, fill = false)
         )
         TerminalInputFiled(
             input = terminalInput,
@@ -134,7 +137,8 @@ fun TerminalScreenContent(
 @Composable
 private fun TerminalOutput(
     output: () -> String,
-    fontSize: () -> TextUnit
+    fontSize: () -> TextUnit,
+    modifier: Modifier = Modifier
 ) {
     val scrollState = rememberScrollState()
     LaunchedEffect(output()) {
@@ -142,7 +146,7 @@ private fun TerminalOutput(
         delay(2000.milliseconds)
     }
     Column(
-        modifier = Modifier
+        modifier = modifier
             .verticalScroll(scrollState)
             .padding(horizontal = 8.dp)
     ) {

--- a/app/src/main/java/micro/repl/ma7moud3ly/screens/terminal/TerminalContent.kt
+++ b/app/src/main/java/micro/repl/ma7moud3ly/screens/terminal/TerminalContent.kt
@@ -324,44 +324,32 @@ private fun ScriptTitle(
     modifier: Modifier = Modifier
 ) {
     val script = microScript()
-    val source = stringResource(
-        id = if (script.isLocal) R.string.this_device else R.string.micro_python
-    )
-    val name = when {
-        script.exists.not() -> ""
-        script.isLocal -> script.name
-        else -> script.path.substringAfterLast('/')
-    }
-    Row(
+    if (script.exists) Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(2.dp),
         verticalAlignment = Alignment.Bottom
     ) {
         Text(
-            text = source,
+            text = stringResource(
+                if (script.isLocal) R.string.this_device
+                else R.string.micro_python
+            ),
             fontFamily = fontConsolas,
+            fontWeight = FontWeight.SemiBold,
             fontSize = 12.sp,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1
         )
-        if (name.isNotEmpty()) {
-            Text(
-                text = "/",
-                fontFamily = fontConsolas,
-                fontSize = 12.sp,
-                color = MaterialTheme.colorScheme.outline
-            )
-            Text(
-                text = name,
-                fontFamily = fontConsolas,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.MiddleEllipsis,
-                modifier = Modifier.weight(1f, fill = false)
-            )
-        }
+        Text(
+            text = script.displayName,
+            fontFamily = fontConsolas,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.MiddleEllipsis,
+            modifier = Modifier.weight(1f, fill = false)
+        )
     }
 }
 


### PR DESCRIPTION
## Editor state across rotation, plus three fixes

- **Rotation lost unsaved edits.** New `EditorSession` holds just the buffer,
  script and saved baseline no Activity references, so it can be retained
  while the manager is rebuilt with live wiring. Also: `canRun` derived instead
  of mirrored, local save off the main thread, dirty dot on Save, Run auto-saves.
- **Terminal input hidden by long output** output had no weight and took the
  whole column.
- **Save shown with no device** a remote script has nowhere to save, so the
  write failed silently.
- **Back from the editor skipped Scripts** it now checks what's underneath, so
  only the explorer is skipped.
